### PR TITLE
10.0.1 fix token exchange encoding

### DIFF
--- a/BoothDownloader/BoothDownloader.csproj
+++ b/BoothDownloader/BoothDownloader.csproj
@@ -6,8 +6,8 @@
         <RootNamespace>BoothDownloader</RootNamespace>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <AssemblyVersion>10.0.0</AssemblyVersion>
-        <FileVersion>10.0.0</FileVersion>
+        <AssemblyVersion>10.0.1</AssemblyVersion>
+        <FileVersion>10.0.1</FileVersion>
         <AssemblyName>BoothDownloader</AssemblyName>
         <PackageId>BoothDownloader</PackageId>
         <Authors>BoothDownloader</Authors>

--- a/BoothDownloader/src/Configuration/BoothConfig.cs
+++ b/BoothDownloader/src/Configuration/BoothConfig.cs
@@ -5,6 +5,7 @@ namespace BoothDownloader.Configuration;
 public class BoothConfig
 {
     public const string DefaultPath = "./BDConfig.json";
+    public const string AnonymousCookie = "ANONYMOUS";
 
     public static void Setup(string path)
     {

--- a/BoothDownloader/src/Miscellaneous/BoothDownloaderProtocol.cs
+++ b/BoothDownloader/src/Miscellaneous/BoothDownloaderProtocol.cs
@@ -109,7 +109,7 @@ public static class BoothDownloaderProtocol
                 if (token != null)
                 {
                     BoothConfig.Setup(BoothConfig.DefaultPath);
-                    BoothConfig.Instance.Cookie = token;
+                    BoothConfig.Instance.Cookie = HttpUtility.UrlEncode(token);
                     BoothConfig.ConfigInstance.Save();
                     LoggerHelper.GlobalLogger.LogInformation("Cookie set from Protocol");
 
@@ -132,7 +132,7 @@ public static class BoothDownloaderProtocol
 
     private static void Exit()
     {
-        LoggerHelper.GlobalLogger.LogInformation("Exiting...");
+        LoggerHelper.GlobalLogger.LogInformation("Exiting in 5 seconds...");
         Thread.Sleep(5000);
         Environment.Exit(0);
     }

--- a/BoothDownloader/src/Program.cs
+++ b/BoothDownloader/src/Program.cs
@@ -97,14 +97,21 @@ internal static class BoothDownloader
             BoothConfig.Setup(configFile);
 
             #region First Boot
+
             if (string.IsNullOrWhiteSpace(BoothConfig.Instance.Cookie))
             {
                 Console.WriteLine("Please paste in your cookie from browser.\n");
                 var cookie = Console.ReadLine();
-                BoothConfig.Instance.Cookie = cookie ?? string.Empty;
+                BoothConfig.Instance.Cookie = string.IsNullOrWhiteSpace(cookie) ? BoothConfig.AnonymousCookie : string.Empty;
                 BoothConfig.ConfigInstance.Save();
                 LoggerHelper.GlobalLogger.LogInformation("Cookie set");
             }
+
+            #endregion
+
+            #region Prep Booth Client
+
+            await BoothHttpClientManager.Setup(cancellationToken);
 
             #endregion
 
@@ -114,11 +121,6 @@ internal static class BoothDownloader
                 Console.Write("> ");
                 boothInput = Console.ReadLine();
             }
-
-            #region Prep Booth Client
-            await BoothHttpClientManager.Setup(cancellationToken);
-
-            #endregion
 
             var commands = boothInput?.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries) ?? [];
             var isLibraryPage = false;

--- a/BoothDownloader/src/Program.cs
+++ b/BoothDownloader/src/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System.CommandLine;
 using System.CommandLine.Builder;
 using System.CommandLine.Parsing;
+using System.Text;
 using BoothDownloader.Configuration;
 using BoothDownloader.Miscellaneous;
 using BoothDownloader.Web;
@@ -14,6 +15,7 @@ internal static class BoothDownloader
     private static async Task<int> Main(string[] args)
     {
         Console.Title = $"BoothDownloader - V{typeof(BoothDownloader).Assembly.GetName().Version}";
+        Console.OutputEncoding = Encoding.Unicode;
         LoggerHelper.GlobalLogger.LogInformation("Booth Downloader - V{Version}", typeof(BoothDownloader).Assembly.GetName().Version);
 
         Environment.CurrentDirectory = AppContext.BaseDirectory;
@@ -95,7 +97,7 @@ internal static class BoothDownloader
             BoothConfig.Setup(configFile);
 
             #region First Boot
-            if (BoothConfig.Instance.Cookie == null)
+            if (string.IsNullOrWhiteSpace(BoothConfig.Instance.Cookie))
             {
                 Console.WriteLine("Please paste in your cookie from browser.\n");
                 var cookie = Console.ReadLine();
@@ -179,6 +181,9 @@ internal static class BoothDownloader
                 if (BoothHttpClientManager.IsAnonymous)
                 {
                     LoggerHelper.GlobalLogger.LogError("Cannot download Paid Items with invalid cookie.");
+                    LoggerHelper.GlobalLogger.LogInformation("Exiting in 5 seconds...");
+                    Thread.Sleep(5000);
+                    Environment.Exit(0);
                 }
                 else
                 {

--- a/BoothDownloader/src/Program.cs
+++ b/BoothDownloader/src/Program.cs
@@ -165,10 +165,8 @@ internal static class BoothDownloader
                         var boothId = RegexStore.IdRegex.Matches(command).Select(x => x.Groups[1].Value).Distinct();
                         if (!boothId.Any())
                         {
-                            LoggerHelper.GlobalLogger.LogWarning("Could not parse booth IDs, assuming provided value is ID");
-                            boothId = [command];
+                            LoggerHelper.GlobalLogger.LogError("Could not parse booth IDs, {command}", command);
                         }
-
                         boothIds.AddRange(boothId);
                     }
                 }
@@ -181,9 +179,8 @@ internal static class BoothDownloader
                 if (BoothHttpClientManager.IsAnonymous)
                 {
                     LoggerHelper.GlobalLogger.LogError("Cannot download Paid Items with invalid cookie.");
-                    LoggerHelper.GlobalLogger.LogInformation("Exiting in 5 seconds...");
+                    LoggerHelper.GlobalLogger.LogInformation("Continuing in 5 seconds...");
                     Thread.Sleep(5000);
-                    Environment.Exit(0);
                 }
                 else
                 {
@@ -214,7 +211,8 @@ internal static class BoothDownloader
             }
             else
             {
-                LoggerHelper.GlobalLogger.LogInformation("No items found to download.");
+                LoggerHelper.GlobalLogger.LogError("No items found to download, exiting in 5 seconds");
+                Thread.Sleep(5000);
             }
         }, registerOption, unregisterOption, configOption, boothOption, outputDirectoryOption, maxRetriesOption, debugOption, cancellationTokenValueSource);
 

--- a/BoothDownloader/src/Web/BoothHttpClientManager.cs
+++ b/BoothDownloader/src/Web/BoothHttpClientManager.cs
@@ -24,6 +24,12 @@ public static class BoothHttpClientManager
 
     public static async Task Setup(CancellationToken cancellationToken)
     {
+        if (BoothConfig.Instance.Cookie == BoothConfig.AnonymousCookie)
+        {
+            LoggerHelper.GlobalLogger.LogWarning("Using anonymous cookie - Purchased file downloads will not function.");
+            return;
+        }
+
         var httpClient = new HttpClient(HttpHandler);
         httpClient.DefaultRequestHeaders.Add("Cookie", $"adult=t{(string.IsNullOrWhiteSpace(BoothConfig.Instance.Cookie) ? string.Empty : $"; _plaza_session_nktz7u={BoothConfig.Instance.Cookie}")}");
 


### PR DESCRIPTION
This patch will close #12 and addresses issues with token being set from the user script being not URL encoded resulting in failed token exchange with booth.pm when using user-script token button, this also addresses some issues with simple checks with the cookie if its null or white spaced.