### PR TITLE
Implement retry mechanism for deletion errors

### DIFF
--- a/BoothDownloader/src/Miscellaneous/Utils.cs
+++ b/BoothDownloader/src/Miscellaneous/Utils.cs
@@ -47,56 +47,27 @@ public static class Utils
 
     public static bool TryDeleteDirectoryWithRetry(string path, out Exception? exception)
     {
-        exception = null;
-        while (true)
-        {
-            try
-            {
-                if (Directory.Exists(path))
-                {
-                    Directory.Delete(path, true);
-                }
-                return true;
-            }
-            catch (Exception ex)
-            {
-                exception = ex;
-                var userDecision = GetUserDecision($"Failed to delete directory: {path}. Error: {ex.Message}");
-                if (userDecision == UserDecision.Retry)
-                {
-                    continue;
-                }
-
-                if (userDecision == UserDecision.Skip)
-                {
-                    return false;
-                }
-
-                if (userDecision == UserDecision.Quit)
-                {
-                    Environment.Exit(0);
-                }
-            }
-        }
+        return TryActionWithRetry(actionDescription: $"delete directory: {path}", action: () => Directory.Delete(path, recursive: true), exception: out exception);
     }
 
     public static bool TryDeleteFileWithRetry(string path, out Exception? exception)
+    {
+        return TryActionWithRetry(actionDescription: $"delete file: {path}", action: () => File.Delete(path), exception: out exception);
+    }
+
+    private static bool TryActionWithRetry(string actionDescription, Action action, out Exception? exception)
     {
         exception = null;
         while (true)
         {
             try
             {
-                if (File.Exists(path))
-                {
-                    File.Delete(path);
-                }
-                return true;
+                action();
             }
             catch (Exception ex)
             {
                 exception = ex;
-                var userDecision = GetUserDecision($"Failed to delete file: {path}. Error: {ex.Message}");
+                var userDecision = GetUserDecision($"Failed to {actionDescription}. Error: {ex.Message}");
                 if (userDecision == UserDecision.Retry)
                 {
                     continue;
@@ -114,6 +85,7 @@ public static class Utils
             }
         }
     }
+
 
     private static UserDecision GetUserDecision(string message)
     {

--- a/BoothDownloader/src/Miscellaneous/Utils.cs
+++ b/BoothDownloader/src/Miscellaneous/Utils.cs
@@ -47,12 +47,24 @@ public static class Utils
 
     public static bool TryDeleteDirectoryWithRetry(string path, out Exception? exception)
     {
-        return TryActionWithRetry(actionDescription: $"delete directory: {path}", action: () => Directory.Delete(path, recursive: true), exception: out exception);
+        return TryActionWithRetry(actionDescription: $"delete directory: {path}",
+            action: () =>
+            {
+                if(Directory.Exists(path))
+                    Directory.Delete(path, recursive: true);
+            },
+            exception: out exception);
     }
 
     public static bool TryDeleteFileWithRetry(string path, out Exception? exception)
     {
-        return TryActionWithRetry(actionDescription: $"delete file: {path}", action: () => File.Delete(path), exception: out exception);
+        return TryActionWithRetry(actionDescription: $"delete file: {path}",
+            action: () =>
+            {
+                if(File.Exists(path))
+                    File.Delete(path);
+            },
+            exception: out exception);
     }
 
     private static bool TryActionWithRetry(string actionDescription, Action action, out Exception? exception)

--- a/BoothDownloader/src/Miscellaneous/Utils.cs
+++ b/BoothDownloader/src/Miscellaneous/Utils.cs
@@ -75,6 +75,7 @@ public static class Utils
             try
             {
                 action();
+                return true;
             }
             catch (Exception ex)
             {

--- a/BoothDownloader/src/Miscellaneous/Utils.cs
+++ b/BoothDownloader/src/Miscellaneous/Utils.cs
@@ -44,4 +44,102 @@ public static class Utils
 
         return newFilename;
     }
+
+    public static bool TryDeleteDirectoryWithRetry(string path, out Exception? exception)
+    {
+        exception = null;
+        while (true)
+        {
+            try
+            {
+                if (Directory.Exists(path))
+                {
+                    Directory.Delete(path, true);
+                }
+                return true;
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+                var userDecision = GetUserDecision($"Failed to delete directory: {path}. Error: {ex.Message}");
+                if (userDecision == UserDecision.Retry)
+                {
+                    continue;
+                }
+
+                if (userDecision == UserDecision.Skip)
+                {
+                    return false;
+                }
+
+                if (userDecision == UserDecision.Quit)
+                {
+                    Environment.Exit(0);
+                }
+            }
+        }
+    }
+
+    public static bool TryDeleteFileWithRetry(string path, out Exception? exception)
+    {
+        exception = null;
+        while (true)
+        {
+            try
+            {
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+                return true;
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+                var userDecision = GetUserDecision($"Failed to delete file: {path}. Error: {ex.Message}");
+                if (userDecision == UserDecision.Retry)
+                {
+                    continue;
+                }
+
+                if (userDecision == UserDecision.Skip)
+                {
+                    return false;
+                }
+
+                if (userDecision == UserDecision.Quit)
+                {
+                    Environment.Exit(0);
+                }
+            }
+        }
+    }
+
+    private static UserDecision GetUserDecision(string message)
+    {
+        Console.WriteLine($"{message}\nChoose an option: Retry (r), Skip (s), Quit (q)");
+        while (true)
+        {
+            var userInput = Console.ReadKey(intercept: true).Key;
+            switch (userInput)
+            {
+                case ConsoleKey.R:
+                    return UserDecision.Retry;
+                case ConsoleKey.S:
+                    return UserDecision.Skip;
+                case ConsoleKey.Q:
+                    return UserDecision.Quit;
+                default:
+                    Console.WriteLine("Invalid option. Please choose: Retry (r), Skip (s), Quit (q)");
+                    break;
+            }
+        }
+    }
+
+    private enum UserDecision
+    {
+        Retry,
+        Skip,
+        Quit
+    }
 }

--- a/BoothDownloader/src/Web/BoothBatchDownloader.cs
+++ b/BoothDownloader/src/Web/BoothBatchDownloader.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 using System.IO.Compression;
 using BoothDownloader.Configuration;
 using BoothDownloader.Miscellaneous;
@@ -42,7 +42,11 @@ public static class BoothBatchDownloader
             if (Directory.Exists(Path.Combine(outputDir, boothItem.Key)))
             {
                 LoggerHelper.GlobalLogger.LogInformation("Directory already exists, deleting: {directoryName}", Path.Combine(outputDir, boothItem.Key));
-                Directory.Delete(Path.Combine(outputDir, boothItem.Key), true);
+                if (!Utils.TryDeleteDirectoryWithRetry(Path.Combine(outputDir, boothItem.Key), out var exception))
+                {
+                    LoggerHelper.GlobalLogger.LogError(exception, "Failed to delete directory: {directoryName}", Path.Combine(outputDir, boothItem.Key));
+                    continue;
+                }
             }
 
             var entryDir = Directory.CreateDirectory(Path.Combine(outputDir, boothItem.Key)).ToString();
@@ -170,7 +174,11 @@ public static class BoothBatchDownloader
                 if (File.Exists(zipFileName))
                 {
                     LoggerHelper.GlobalLogger.LogInformation("File already exists, deleting: {fileName}", zipFileName);
-                    File.Delete(zipFileName);
+                    if (!Utils.TryDeleteFileWithRetry(zipFileName, out var exception))
+                    {
+                        LoggerHelper.GlobalLogger.LogError(exception, "Failed to delete file: {fileName}", zipFileName);
+                        continue;
+                    }
                 }
 
                 LoggerHelper.GlobalLogger.LogInformation("Zipping");
@@ -178,7 +186,11 @@ public static class BoothBatchDownloader
                 LoggerHelper.GlobalLogger.LogInformation("Zipped");
 
 
-                Directory.Delete(entryDir, true);
+                if (!Utils.TryDeleteDirectoryWithRetry(entryDir, out var dirException))
+                {
+                    LoggerHelper.GlobalLogger.LogError(dirException, "Failed to delete directory after zipping: {directoryName}", entryDir);
+                    continue;
+                }
 
                 LoggerHelper.GlobalLogger.LogInformation("ENVFilePATH: {filePath}", zipFileName);
             }

--- a/BoothDownloader/src/Web/BoothBatchDownloader.cs
+++ b/BoothDownloader/src/Web/BoothBatchDownloader.cs
@@ -189,6 +189,7 @@ public static class BoothBatchDownloader
                 if (!Utils.TryDeleteDirectoryWithRetry(entryDir, out var dirException))
                 {
                     LoggerHelper.GlobalLogger.LogError(dirException, "Failed to delete directory after zipping: {directoryName}", entryDir);
+                    LoggerHelper.GlobalLogger.LogInformation("ENVFileDIR: {directoryPath}", entryDir);
                     continue;
                 }
 


### PR DESCRIPTION
This PR was entirely made using Github Copilot Workspace.
Some small optimizations need to be done before merging.

---

Closes #16

Implements a retry mechanism for file and directory deletion operations, enhancing error handling and user interaction.

- **Error Handling Enhancements**
  - Adds `TryDeleteDirectoryWithRetry` and `TryDeleteFileWithRetry` methods in `Utils.cs` to attempt deletion with a retry mechanism. These methods loop until the operation succeeds, the user decides to skip, or the user quits the program.
  - Incorporates user prompts within the retry mechanism, offering options to retry, skip, or quit upon encountering deletion errors.
  
- **Integration with Existing Code**
  - Utilizes the new retry mechanism methods in `BoothBatchDownloader.cs` for deleting directories and files. This ensures that if a deletion fails, the user is prompted with options to handle the error gracefully.
  - Modifies directory and file deletion logic to use the retry mechanism, improving robustness against locked files or other deletion errors.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Myrkie/BoothDownloader/issues/16?shareId=ec36f23d-12ca-424b-9276-ed3afbeb8940).